### PR TITLE
Fixed a bug with the color conversion on an Arduino Nano

### DIFF
--- a/Framebuffer_GFX.cpp
+++ b/Framebuffer_GFX.cpp
@@ -149,7 +149,7 @@ uint16_t Framebuffer_GFX::Color24to16(uint32_t color) {
 }
 
 uint32_t Framebuffer_GFX::CRGBtoint32(CRGB c) {
-  return c.r*65536+c.g*256+c.b;
+  return c.r*(uint32_t)65536+c.g*(uint32_t)256+c.b;
 }
 
 


### PR DESCRIPTION
This PR fixes a bug I had with the color conversion on the Arduino Nano with WS8212B LEDs. Green would appear as yellow and I couldn't figure out why since using FastLED directly would not cause the bug. I narrowed it down to the `CRGBtoint32` method, which would return a value close to 4294967296 when plugging in `CRGB::Green`. Apparently, integer constants work differently between the ESP8266 (I had been using previously) and the Arduino Nano and explicitly declaring the constants as `uint32_t` fixes the issue.